### PR TITLE
Change to auto tele update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,20 @@ Pre-requirements:
 2. The integration is currently based on latest dev release of Tasmota, because of recent modification requested to @curzon01 that he quickly implemented in [#19857](https://github.com/arendst/Tasmota/pull/19857), and has already been merged. Next stable release (after v13.2.0, current stable version) should contain #19857. I will update notes to specify the stable min. version once known.
 3. From Tasmota console, run these commands to optimize the device configuration:
 
-    _This sets the SENSOR topic update frequency to 20s and sets the Retain flag so that HA entities are immediately available_
+    _This sets Retain flag for telemetry topic so that HA entities are immediately available_
     ```console
-    BackLog TelePeriod 20; SensorRetain 1;
+    SensorRetain 1
     ```
     _This ensures that Tasmota %topic% is set to `SmartPool` so you don't have to change all the topics in the package file_
     ```console
-    BackLog SetOption4 1; Topic SmartPool;
+    Topic SmartPool
     ```
-    _This rule keeps the Sugar Valley device clock in sync with Tasmota's device clock_
+    _This rule keeps the Sugar Valley device clock in sync with Tasmota's device clock_ and set NeoPool auto SENSOR topic update and with 5 sec delay for often changed (measured) values
     ```console
     Rule1
       ON Time#Initialized DO NPTime 0 ENDON
       ON Time#Set DO NPTime 0 ENDON
+      ON System#Init NPTeleperiod 5 ENDON
     Backlog Rule1 4;Rule1 1
     ```
 4. Home Assistant MQTT integration properly configured and working

--- a/ha-neopool-mqtt-package.yaml
+++ b/ha-neopool-mqtt-package.yaml
@@ -406,14 +406,14 @@ mqtt:
     - unique_id: "neopool_mqtt_filtration_switch"
       name: "NeoPool MQTT Filtration Switch"
       device_class: switch
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPFiltration"
       state_topic: "tele/SmartPool/SENSOR"
       value_template: >-
         {{ value_json.NeoPool.Filtration.State }}
       optimistic: false
       retain: false
-      payload_on: "NPFiltration 1;Delay 30;Teleperiod"
-      payload_off: "NPFiltration 0;Delay 30;Teleperiod"
+      payload_on: "1"
+      payload_off: "0"
       state_on: 1
       state_off: 0
       availability_topic: "tele/SmartPool/LWT"
@@ -422,14 +422,14 @@ mqtt:
     - unique_id: "neopool_mqtt_light_switch"
       name: "NeoPool MQTT Light Switch"
       device_class: switch
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPLight"
       state_topic: "tele/SmartPool/SENSOR"
       optimistic: false
       retain: false
       value_template: >-
         {{ value_json.NeoPool.Light }}
-      payload_on: "NPLight 1;Delay 30;Teleperiod"
-      payload_off: "NPLight 0;Delay 30;Teleperiod"
+      payload_on: "1"
+      payload_off: "0"
       state_on: 1
       state_off: 0
       availability_topic: "tele/SmartPool/LWT"
@@ -438,14 +438,14 @@ mqtt:
     - unique_id: "neopool_mqtt_aux1_switch"
       name: "NeoPool MQTT AUX1 Switch"
       device_class: switch
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPAux1"
       state_topic: "tele/SmartPool/SENSOR"
       optimistic: false
       retain: false
       value_template: >-
-        {{ value_json.NeoPool.Relay.State[3] }}
-      payload_on: "NPAux1 1;Delay 30;Teleperiod"
-      payload_off: "NPAux1 0;Delay 30;Teleperiod"
+        {{ value_json.NeoPool.Relay.Aux[0] }}
+      payload_on: "1"
+      payload_off: "0"
       state_on: 1
       state_off: 0
       availability_topic: "tele/SmartPool/LWT"
@@ -454,14 +454,14 @@ mqtt:
     - unique_id: "neopool_mqtt_aux2_switch"
       name: "NeoPool MQTT AUX2 Switch"
       device_class: switch
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPAux2"
       state_topic: "tele/SmartPool/SENSOR"
       optimistic: false
       retain: false
       value_template: >-
-        {{ value_json.NeoPool.Relay.State[4] }}
-      payload_on: "NPAux2 1;Delay 30;Teleperiod"
-      payload_off: "NPAux2 0;Delay 30;Teleperiod"
+        {{ value_json.NeoPool.Relay.Aux[1] }}
+      payload_on: "1"
+      payload_off: "0"
       state_on: 1
       state_off: 0
       availability_topic: "tele/SmartPool/LWT"
@@ -470,14 +470,14 @@ mqtt:
     - unique_id: "neopool_mqtt_aux3_switch"
       name: "NeoPool MQTT AUX3 Switch"
       device_class: switch
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPAux3"
       state_topic: "tele/SmartPool/SENSOR"
       optimistic: false
       retain: false
       value_template: >-
-        {{ value_json.NeoPool.Relay.State[5] }}
-      payload_on: "NPAux3 1;Delay 30;Teleperiod"
-      payload_off: "NPAux3 0;Delay 30;Teleperiod"
+        {{ value_json.NeoPool.Relay.Aux[2] }}
+      payload_on: "1"
+      payload_off: "0"
       state_on: 1
       state_off: 0
       availability_topic: "tele/SmartPool/LWT"
@@ -486,14 +486,14 @@ mqtt:
     - unique_id: "neopool_mqtt_aux4_switch"
       name: "NeoPool MQTT AUX4 Switch"
       device_class: switch
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPAux4"
       state_topic: "tele/SmartPool/SENSOR"
       optimistic: false
       retain: false
       value_template: >-
-        {{ value_json.NeoPool.Relay.State[6] }}
-      payload_on: "NPAux4 1;Delay 30;Teleperiod"
-      payload_off: "NPAux4 0;Delay 30;Teleperiod"
+        {{ value_json.NeoPool.Relay.Aux[3] }}
+      payload_on: "1"
+      payload_off: "0"
       state_on: 1
       state_off: 0
       availability_topic: "tele/SmartPool/LWT"
@@ -507,11 +507,11 @@ mqtt:
       value_template: >-
         {% set values = { 0:'Manual', 1:'Auto', 2:'Heating', 3:'Smart', 4:'Intelligent', 13:'Backwash' } %}
         {{ values[value_json.NeoPool.Filtration.Mode] if value_json.NeoPool.Filtration.Mode in values.keys() }}
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPFiltrationmode"
       command_template: >-
         {% set values = { 'Manual':0, 'Auto':1, 'Heating':2, 'Smart':3, 'Intelligent':4, 'Backwash':13 } %}
         {% set setvalue = values[value] | string if value in values.keys() %}
-        {{ 'NPFiltrationmode ' + setvalue +';Delay 30;Teleperiod' }}
+        {{ setvalue }}
       optimistic: false
       retain: false
       options: ["Manual", "Auto", "Heating", "Smart", "Intelligent", "Backwash"]
@@ -524,11 +524,11 @@ mqtt:
       value_template: >-
         {% set values = { 1:'Slow', 2:'Medium', 3:'Fast' } %}
         {{ values[value_json.NeoPool.Filtration.Speed] if value_json.NeoPool.Filtration.Speed in values.keys() }}
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPFiltrationSpeed"
       command_template: >-
         {% set values = { 'Slow':1, 'Medium':2, 'Fast':3 } %}
         {% set setvalue = values[value] | string if value in values.keys() %}
-        {{ 'NPFiltrationSpeed ' + setvalue +';Delay 30;Teleperiod' }}
+        {{ setvalue }}
       optimistic: false
       retain: false
       options: ["Slow", "Medium", "Fast"]
@@ -541,11 +541,11 @@ mqtt:
       value_template: >-
         {% set values = { 0:'Off', 1:'On', 2:'On (Redox)' } %}
         {{ values[value_json.NeoPool.Hydrolysis.Boost] if value_json.NeoPool.Hydrolysis.Boost in values.keys() }}
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPBoost"
       command_template: >-
         {% set values = { 'Off':0, 'On':1, 'On (Redox)':2 } %}
         {% set setvalue = values[value] | string if value in values.keys() %}
-        {{ 'NPBoost ' + setvalue +';Delay 30;Teleperiod' }}
+        {{ setvalue }}
       optimistic: false
       retain: false
       options: ["Off", "On", "On (Redox)"]
@@ -564,9 +564,9 @@ mqtt:
       state_topic: "tele/SmartPool/SENSOR"
       value_template: >-
         {{ value_json.NeoPool.pH.Min }}
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPpHMin"
       command_template: >-
-        {{ 'NPpHMin ' + value|string +';Delay 30;Teleperiod' }}
+        {{ value|string }}
       optimistic: false
       retain: false
       availability_topic: "tele/SmartPool/LWT"
@@ -582,9 +582,9 @@ mqtt:
       state_topic: "tele/SmartPool/SENSOR"
       value_template: >-
         {{ value_json.NeoPool.pH.Max }}
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPpHMax"
       command_template: >-
-        {{ 'NPpHMax ' + value|string +';Delay 30;Teleperiod' }}
+        {{ value|string }}
       optimistic: false
       retain: false
       availability_topic: "tele/SmartPool/LWT"
@@ -601,9 +601,9 @@ mqtt:
       state_topic: "tele/SmartPool/SENSOR"
       value_template: >-
         {{ value_json.NeoPool.Redox.Setpoint }}
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPRedox"
       command_template: >-
-        {{ 'NPRedox ' + value|string +';Delay 30;Teleperiod' }}
+        {{ value|string }}
       optimistic: false
       retain: false
       availability_topic: "tele/SmartPool/LWT"
@@ -619,9 +619,9 @@ mqtt:
       state_topic: "tele/SmartPool/SENSOR"
       value_template: >-
         {{ value_json.NeoPool.Hydrolysis.Percent.Setpoint }}
-      command_topic: "cmnd/SmartPool/Backlog"
+      command_topic: "cmnd/SmartPool/NPHydrolysis"
       command_template: >-
-        {{ 'NPHydrolysis ' + value|string +'%;Delay 30;Teleperiod' }}
+        {{ value|string }}
       optimistic: false
       retain: false
       availability_topic: "tele/SmartPool/LWT"


### PR DESCRIPTION
Makes the `Backlog <cmnd>;Delay 30;Teleperiod` obsolete.

This PR only works with the appened Tasmota FW. It implements a new cmnd `NPTelePeriod` to enable auto sending SENSOR topic on system value changes, `NPTelePeriod 0` disable this - this is always the default after Tamota starts. 

Short desc:

```
NPTelePeriod {time}
           enables the auto reporting on system value changes (<time> = 0..TelePeriod)
           <time> is the minimum of seconds between two reportings or 0 to switch off the function
           <time> only applies to changes for measured values, status changes such as filtration
           light, pH setpoint etc. always trigger an immediate report if this function is enabled
           (<time> != 0)
```

The `NPTelePeriod` setting will not be permanently stored, so it must be set by RULE during Tasmota start so I add a `ON System#Init NPTeleperiod 5 ENDON` to the default rule.

`NPTeleperiod 5` for example means:
- auto sending SENSOR is enabled
- the trigger for sending is if a SENSOR related value within the system changes (some with delay of 5 sec)
- state value changes like relay, light etc. are triggering immediately
- values which are measured (temperature, redox etc.) are triggered earliest after 5 sec after the change - the 5 is a delay prevent flooding SENSOR topic sends. I'd use 5 for start, but you can use every value from 1 to `TelePeriod` setting.

You will the the changes are visibile more or less immediatley - it still takes 1-3 seconds e.g. when switching the filtration but this depends on the processing time of the SV system


Here the Tasmota FW with debug enabled - use `Weblog 3` or `Weblog 4` to see the sensor debug values. `Weblog 2` get's back to normal logging:

[tasmota32-neopool-dev.zip](https://github.com/alexdelprete/HA-NeoPool-MQTT/files/13299275/tasmota32-neopool-dev.zip)

If you aprove it, I will create a Tasmota PR